### PR TITLE
Automate Docker setup to remove manual post-installation steps (#140)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,3 +51,9 @@ EXPOSE 8000:80
 
 # Start Apache
 CMD ["apache2-foreground"]
+# Copy the entrypoint script into the image
+COPY docker-entrypoint.sh /var/www/html/docker-entrypoint.sh
+
+# Make sure it is executable
+RUN chmod +x /var/www/html/docker-entrypoint.sh
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,6 @@
+version: '3'
+
+services:
   app:
     build:
       context: .
@@ -18,8 +21,41 @@
       - ./:/var/www/html
       - /var/www/html/node_modules
       - /var/www/html/vendor
-    entrypoint: ["/var/www/html/docker-entrypoint.sh"]
+    entrypoint: ["/var/www/html/docker-entrypoint.sh"]   # <-- this is the only line you add
     depends_on:
       - db
     networks:
       - laravel-network
+
+  db:
+    image: mysql:8.0
+    container_name: samarium_db
+    restart: unless-stopped
+    environment:
+      MYSQL_DATABASE: samarium
+      MYSQL_USER: samarium_user
+      MYSQL_PASSWORD: samarium_password
+      MYSQL_ROOT_PASSWORD: secret
+    volumes:
+      - dbdata:/var/lib/mysql
+    ports:
+      - "21876:3306"
+    networks:
+      - laravel-network
+
+  redis:
+    image: redis:alpine
+    container_name: samarium_redis
+    restart: unless-stopped
+    networks:
+      - laravel-network
+
+networks:
+  laravel-network:
+    driver: bridge
+
+volumes:
+  laravel-storage:
+  laravel-cache:
+  dbdata:
+    driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,3 @@
-version: '3'
-
-services:
   app:
     build:
       context: .
@@ -21,40 +18,8 @@ services:
       - ./:/var/www/html
       - /var/www/html/node_modules
       - /var/www/html/vendor
+    entrypoint: ["/var/www/html/docker-entrypoint.sh"]
     depends_on:
       - db
     networks:
       - laravel-network
-
-  db:
-    image: mysql:8.0
-    container_name: samarium_db
-    restart: unless-stopped
-    environment:
-      MYSQL_DATABASE: samarium
-      MYSQL_USER: samarium_user
-      MYSQL_PASSWORD: samarium_password
-      MYSQL_ROOT_PASSWORD: secret
-    volumes:
-      - dbdata:/var/lib/mysql
-    ports:
-      - "21876:3306"
-    networks:
-      - laravel-network
-
-  redis:
-    image: redis:alpine
-    container_name: samarium_redis
-    restart: unless-stopped
-    networks:
-      - laravel-network
-
-networks:
-  laravel-network:
-    driver: bridge
-
-volumes:
-  laravel-storage:
-  laravel-cache:
-  dbdata:
-    driver: local

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+echo "Waiting for the database..."
+until nc -z db 3306; do
+  sleep 1
+done
+echo "Database is up."
+
+composer install --no-interaction
+npm install
+
+php artisan key:generate
+php artisan migrate --force
+php artisan db:seed --force
+php artisan storage:link
+composer dump-autoload
+
+exec npm run dev


### PR DESCRIPTION
## Summary

This PR introduces a `docker-entrypoint.sh` script and updates the Dockerfile and docker-compose.yml to fully automate the Laravel setup process when running: